### PR TITLE
Bugfix on reaching local Ollama

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,23 +3,13 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.dashboard
-      network: host
-    ports:
-      - "8050:8050"
+    network_mode: "host"  # Use host network mode
     volumes:
       - ./llm_responses:/app/llm_responses
       - ./cache:/app/cache
       - ./.env.default:/app/.env.default
     environment:
-      - OLLAMA_HOST=host.docker.internal
+      - OLLAMA_HOST=localhost
       - OPENAI_API_KEY=${OPENAI_API_KEY:-dummy_key}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-dummy_key}
       - GROQ_API_KEY=${GROQ_API_KEY:-dummy_key}
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    networks:
-      - ai-dashboard-net
-
-networks:
-  ai-dashboard-net:
-    driver: bridge

--- a/docker/Dockerfile.dashboard
+++ b/docker/Dockerfile.dashboard
@@ -41,5 +41,9 @@ RUN mkdir -p /app/llm_responses /app/cache
 # Expose port
 EXPOSE 8050
 
+# Add healthcheck
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:8050/ || exit 1s
+
 # Run the application
 CMD ["uv", "run", "ai_dashboard_builder"]


### PR DESCRIPTION
Solving #9 

Networking settings on `docker-compose.yml` were too restrictive for the app to reach a locally running instance of Ollama.